### PR TITLE
Add option to build the SDK/library with Link-Time Optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,14 @@ set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output )
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output )
 set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output )
 
+include(CheckCXXCompilerFlag)
+macro(check_and_add_flag var flag)
+    CHECK_CXX_COMPILER_FLAG(${flag} FLAG_${var})
+    if(FLAG_${var})
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+    endif()
+endmacro()
+
 # Second, for multi-config builds (e.g. msvc)
 foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
     string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
@@ -41,6 +49,15 @@ endif()
 # The primary SDK artifact, a static library for Oculus access 
 add_subdirectory(LibOVR)
 set_target_properties(OculusVR PROPERTIES FOLDER "Oculus")
+
+option(ENABLE_LTO "Build with Link-Time Optimization" FALSE)
+if(ENABLE_LTO)
+    check_and_add_flag(LTO -flto)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+        set(CMAKE_AR gcc-ar)
+        set(CMAKE_RANLIB gcc-ranlib)
+    endif()
+endif()
 
 ###############################################################################
 #


### PR DESCRIPTION
This is used pretty heavily on the Dolphin-Emu project, so I figured it might be quite useful here.
