### PR TITLE
Fix context restore issue when dismissing HSW in OpenGL

### DIFF
--- a/LibOVR/Src/CAPI/GL/CAPI_GL_HSWDisplay.cpp
+++ b/LibOVR/Src/CAPI/GL/CAPI_GL_HSWDisplay.cpp
@@ -313,24 +313,24 @@ void HSWDisplay::UnloadGraphics()
         currentGLContext.InitFromCurrent();
         GLContext.Bind();
 
-    // RenderParams: No need to clear.
-    if(FrameBuffer != 0)
-    {
-        glDeleteFramebuffers(1, &FrameBuffer);
-        FrameBuffer = 0;
-    }
-    pTexture.Clear();
-    pShaderSet.Clear();
-    pVertexShader.Clear();
-    pFragmentShader.Clear();
-    pVB.Clear();
-    if(VAO)
-    {
+        // RenderParams: No need to clear.
+        if(FrameBuffer != 0)
+        {
+            glDeleteFramebuffers(1, &FrameBuffer);
+            FrameBuffer = 0;
+        }
+        pTexture.Clear();
+        pShaderSet.Clear();
+        pVertexShader.Clear();
+        pFragmentShader.Clear();
+        pVB.Clear();
+        if(VAO)
+        {
             glDeleteVertexArrays(1, &VAO);
+        }
         currentGLContext.Bind();
         GLContext.Destroy();
     }
-}
 }
 
 


### PR DESCRIPTION
Not sure if you're taking functional fixes in this repo. But the potential impact of this issue seemed broad to me.

I haven't heard back from Oculus on this, but I assume the fact that the user's GL context isn't restored when there's no VAO in this cleanup code is unintentional. And it easily leads to crashes in client apps that don't realize dismissing the HSW is going to take away their GL context.

