### PR TITLE
Remove unsupported  linux gcc CXX_FLAG -stdlib=libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(WIN32)
 elseif(APPLE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
 else() 
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
 # The primary SDK artifact, a static library for Oculus access 


### PR DESCRIPTION
This flag generates a build error ('unsupported option' or similar) on Ubuntu 14.10; I believe the flag is for clang only on Mac OSX?