### PR TITLE
Use glXQueryContext instead of glXQueryDrawable to get GLX_FBCONFIG.

### DIFF
--- a/LibOVR/Src/Displays/OVR_Linux_SDKWindow.cpp
+++ b/LibOVR/Src/Displays/OVR_Linux_SDKWindow.cpp
@@ -245,9 +245,9 @@ bool SDKWindow::getVisualFromDrawable(GLXDrawable drawable, XVisualInfo* vinfoOu
 {
     struct _XDisplay* display = glXGetCurrentDisplay();
 
-    unsigned int value;
-    glXQueryDrawable(display, drawable, GLX_FBCONFIG_ID, &value);
-    const int attribs[] = {GLX_FBCONFIG_ID, (int)value, None};
+    int value;
+    glXQueryContext(display, glXGetCurrentContext(), GLX_FBCONFIG_ID, &value);
+    const int attribs[] = {GLX_FBCONFIG_ID, value, None};
     int screen;
     glXQueryContext(display, glXGetCurrentContext(), GLX_SCREEN, &screen);
     int numElems;


### PR DESCRIPTION
This is a fix from haagch, and others, to fix an ongoing issue with the Oculus SDK and open source GL drivers on Linux.  You can see more details of the issue on the forums:
https://forums.oculus.com/viewtopic.php?t=16664